### PR TITLE
RS-485 Addressing

### DIFF
--- a/SerialCommand.cpp
+++ b/SerialCommand.cpp
@@ -57,6 +57,23 @@ void SerialCommand::addCommand(const char *command, void (*function)()) {
 }
 
 /**
+ * Similar to the addCommand() function above, this appends char address to the beginning of the command.
+ * This is intended to assist in RS-485 situations where addressing is required.
+ */
+void SerialCommand::addCommandWithAddr(const char *command, void (*function)()){
+  String tmp = String(address)+String(command);
+  char charBuf[50];
+  tmp.toCharArray(charBuf,50);
+  commandList = (SerialCommandCallback *) realloc(commandList, (commandCount + 1) * sizeof(SerialCommandCallback));
+  strncpy(commandList[commandCount].command, charBuf, SERIALCOMMAND_MAXCOMMANDLENGTH);
+  commandList[commandCount].function = function;
+  commandCount++;
+}
+
+void SerialCommand::setAddress(char addin){
+  address = addin;
+}
+/**
  * This sets up a handler to be called in the event that the receveived command string
  * isn't in the list of commands.
  */

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -48,7 +48,7 @@ class SerialCommand {
     void addCommand(const char *command, void(*function)());  // Add a command to the processing dictionary.
     void setDefaultHandler(void (*function)(const char *));   // A handler to call when no valid command received.
 
-    void readSerial(Stream &stream);    // Main entry point.
+    void readSerial(Stream &stream = Serial);    // Main entry point.
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
 

--- a/SerialCommand.h
+++ b/SerialCommand.h
@@ -46,8 +46,9 @@ class SerialCommand {
   public:
     SerialCommand();      // Constructor
     void addCommand(const char *command, void(*function)());  // Add a command to the processing dictionary.
+    void addCommandWithAddr(const char *command, void(*function)());//Add a command to the processing dictionary with address.
     void setDefaultHandler(void (*function)(const char *));   // A handler to call when no valid command received.
-
+    void setAddress(char addin);
     void readSerial(Stream &stream = Serial);    // Main entry point.
     void clearBuffer();   // Clears the input buffer.
     char *next();         // Returns pointer to next token found in command buffer (for getting arguments to commands).
@@ -70,6 +71,7 @@ class SerialCommand {
     char buffer[SERIALCOMMAND_BUFFER + 1]; // Buffer of stored characters while waiting for terminator character
     byte bufPos;                        // Current position in the buffer
     char *last;                         // State variable used by strtok_r during processing
+    char address;
 };
 
 #endif //SerialCommand_h

--- a/examples/SerialCommandExample/SerialCommandExample.pde
+++ b/examples/SerialCommandExample/SerialCommandExample.pde
@@ -19,6 +19,8 @@ void setup() {
   sCmd.addCommand("OFF",   LED_off);         // Turns LED off
   sCmd.addCommand("HELLO", sayHello);        // Echos the string argument back
   sCmd.addCommand("P",     processCommand);  // Converts two arguments to integers and echos them back
+  sCmd.setAddress('A');                      // Sets the address for any calls to addCommandWithAddr()
+  sCmd.addCommandWithAddr("GOODBYE", sayGoodbye); //Adds the command "AGOODBYE" to the list of available commands
   sCmd.setDefaultHandler(unrecognized);      // Handler for command that isn't matched  (says "What?")
   Serial.println("Ready");
 }
@@ -50,6 +52,9 @@ void sayHello() {
   }
 }
 
+void sayGoodbye(){
+  Serial.println("Adios");
+}
 
 void processCommand() {
   int aNumber;


### PR DESCRIPTION
This PR adds Serial as the default stream for the library, allowing users of the original library to leave their old firmware alone, while allowing them to use the hardware serial ports on the AtMega32u4, or alternative hardware serial ports on the AtMega2560.

Also added is addressing in the form of setAddress() and addCommandWithAddr() these functions allow developers to have multiple devices on a single serial bus at a time with similar command sets. The example code has been updated to show how one would use these.